### PR TITLE
Spike devops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17.3)
+cmake_minimum_required(VERSION 3.16.3)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,25 @@
+# Development Guide
+
+## Docker local development setup
+
+1. You should have docker installed in your system, if not click [here](https://docs.docker.com/get-docker/).
+
+2. Build the docker image:
+    ```shell
+    docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
+    ```
+3. Set up CLion:
+    - Navigate to Settings > Build, Execution, Deployment
+      > Toolchains
+    - Select _+_ then choose _Docker_ from the dropdown
+    - Click the gear icon on the right side of the server field
+    - Select the docker image  from the dropdown field
+      labeled _Container Settings_ and wait for CLion to
+      complete the configuration.
+    - Use the container setttings to mount the project root as a volume with the path `/tmp/SimpleDJ`
+		*NOTE*: It has to be an abolute path
+
+4. After configuring a Docker toolchain, you can select it in CMake profiles or in Makefile settings. Alternatively, move the toolchain to the top of the list to make it default.
+5. The project folder will be mounted to the Docker container, and build/run/debug will be performed inside it.
+	*NOTE*: By default, the project folder is mounted into the /tmp folder in the container. However, if there are path mappings specified in the toolchain, CLion will use them instead.
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,3 +33,16 @@
     folder in the container. However, if there are path mappings
     specified in the toolchain, CLion will use them instead.
 
+## Tips
+
+### Useful Docker Commands
+
+Interactive Docker shell for debugging:
+```shell
+docker run --rm -it clion/ubuntu/cpp-env:1.0 /bin/sh
+```
+
+manually mount the volume from project root:
+```shell
+docker run --rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,8 +9,7 @@
     docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
     ```
 3. Set up CLion:
-    - Navigate to Settings > Build, Execution, Deployment
-      > Toolchains
+    - Navigate to Settings > Build, Execution, Deployment > Toolchains
     - Select _+_ then choose _Docker_ from the dropdown
     - Click the gear icon on the right side of the server field
     - Select the docker image  from the dropdown field

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,14 +11,25 @@
 3. Set up CLion:
     - Navigate to Settings > Build, Execution, Deployment > Toolchains
     - Select _+_ then choose _Docker_ from the dropdown
-    - Click the gear icon on the right side of the server field
-    - Select the docker image  from the dropdown field
-      labeled _Container Settings_ and wait for CLion to
-      complete the configuration.
-    - Use the container setttings to mount the project root as a volume with the path `/tmp/SimpleDJ`
-		*NOTE*: It has to be an abolute path
+    - Select the newly created clion container in the dropdown field
+      marked with the _Image_ label. Allow a minute for CLion to complete the configuration
+    - Click the gear icon on the right side of the _Container Settings_
+      field
+    - In the new popup, map the absolute path of your Host's project
+      root to `/app` for the container's path. You can find the options
+      under the Volumes section by clicking the triangle to expand the
+      section labeled _Volumes_ and clicking the _+_ on the top left of
+      the sub-section. i.e.:
+        `/Users/ilovesynervoz/code/SimpleDJ` -> `/app`
+      *NOTE*: It has to be an abolute path
 
-4. After configuring a Docker toolchain, you can select it in CMake profiles or in Makefile settings. Alternatively, move the toolchain to the top of the list to make it default.
-5. The project folder will be mounted to the Docker container, and build/run/debug will be performed inside it.
-	*NOTE*: By default, the project folder is mounted into the /tmp folder in the container. However, if there are path mappings specified in the toolchain, CLion will use them instead.
+4. After configuring a Docker toolchain, you can select it in CMake
+   profiles or in Makefile settings. Alternatively, move the toolchain
+   to the top of the list to make it default.
+
+5. The project folder will be mounted to the Docker container, and
+   build/run/debug will be performed inside it.
+    *NOTE*: By default, the project folder is mounted into the /tmp
+    folder in the container. However, if there are path mappings
+    specified in the toolchain, CLion will use them instead.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 # Build and run:
 #   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
+#   docker run --rm -it clion/ubuntu/cpp-env:1.0 /bin/sh
+#   docker run -rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
 
 # base image
 FROM ubuntu:20.04
 
+# docker defaults to /tmp, clion defaults to /tmp/misc so we avoid that future problem entirely
+WORKDIR /app
+
 #TODO define target-specific env variables
 
-#TODO bring back builder user and set as sudoer
+# set permissions
+RUN chmod 0755 -R /app
 
 # non interactive mode plays nice with CLion debug window
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y install tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # Build and run:
-#   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
-#   docker run --rm -it clion/ubuntu/cpp-env:1.0 /bin/sh
-#   docker run -rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
+# * build the container:
+# #   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
+#
+# Troubleshooting commands:
+# * if you need an interactive docker shell run:
+# #   docker run --rm -it clion/ubuntu/cpp-env:1.0 /bin/sh
+# * and if you don't want to use clion, you can mount the volume using:
+# #   docker run -rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
 
 # base image
 FROM ubuntu:20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # * if you need an interactive docker shell run:
 # #   docker run --rm -it clion/ubuntu/cpp-env:1.0 /bin/sh
 # * and if you don't want to use clion, you can mount the volume using:
-# #   docker run -rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
+# #   docker run --rm -it -v $(pwd):/app clion/ubuntu/cpp-env:1.0
 
 # base image
 FROM ubuntu:20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build and run:
+#   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile.cpp-env-ubuntu .
+
+FROM ubuntu:20.04
+
+RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y install tzdata
+
+RUN apt-get update \
+  && apt-get install -y build-essential \
+      gcc \
+      g++ \
+      gdb \
+      git \
+      clang \
+      make \
+      ninja-build \
+      cmake \
+      autoconf \
+      automake \
+      libtool \
+      valgrind \
+      tar \
+  && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,10 @@ RUN apt-get update \
       automake \
       libtool \
       valgrind \
+      locales-all \
+      dos2unix \
+      rsync \
       tar \
+      python \
+      python-dev \
   && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM ubuntu:20.04
 
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y install tzdata
 
+ARG UID=1000
+RUN useradd -m -u ${UID} -s /bin/bash builder
+USER builder
+
 RUN apt-get update \
   && apt-get install -y build-essential \
       gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 # Build and run:
-#   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile.cpp-env-ubuntu .
+#   docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .
 
+# base image
 FROM ubuntu:20.04
 
+#TODO define target-specific env variables
+
+#TODO bring back builder user and set as sudoer
+
+# non interactive mode plays nice with CLion debug window
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get -y install tzdata
 
-ARG UID=1000
-RUN useradd -m -u ${UID} -s /bin/bash builder
-USER builder
-
+# setup
 RUN apt-get update \
   && apt-get install -y build-essential \
       gcc \
@@ -19,6 +22,12 @@ RUN apt-get update \
       make \
       ninja-build \
       cmake \
+      pkg-config \
+      libfreetype6-dev \
+      libasound2-dev \
+      libwebkit2gtk-4.0-dev \
+      libgtk-3-dev \
+      libcurl4-openssl-dev \
       autoconf \
       automake \
       libtool \


### PR DESCRIPTION
Spike to add devops tooling to the base SimpleDJ project

- [x] containerized Linux build environment

Hopefuls:
- [x] CLion integration
- [ ] multiarch build targets (armv7 et al?)
- [ ] CI/CD beginnings
  - [ ] Profiler
  - [ ] Linter
- [ ] CLI tool
- [ ] Github runner integration
- [ ] migrate container image to alpine
- [ ] multiarch build

To set up the docker environment:
* make sure you have docker, docker-compose, and it's requirements installed on dev machine
* build container from project root using `docker build -t clion/ubuntu/cpp-env:1.0 -f Dockerfile .`
* go to Settings | Build, Execution, Deployment | Toolchains.
* click Add toolchain and select Docker
* click the gear button to the Server field to add a Docker image:
* select the Docker image and wait until the tools detection finishes.

Note: Use the Container Settings field to provide additional container settings, such as port and volume bindings:
Docker container settings